### PR TITLE
Add MAINTAINERS.md file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,32 @@
+# Maintainers
+
+This file lists the maintainers of this repository.
+
+## Current maintainers
+
+| GitHub Username | Name | Organization | Email |
+|----------------|------|--------------|-------|
+| @ChrisTyree | *please add name* | *please add organization* | *please add email* |
+| @alstratigos | *please add name* | FINOS | *please add email* |
+| @eteridvalishvili | *please add name* | *please add organization* | *please add email* |
+| @grizzwolf | Aaron Griswold | FINOS & The Linux Foundation | aaron.griswold@finos.org |
+| @jgavronsky | *please add name* | *please add organization* | *please add email* |
+| @karlmoll | *please add name* | @finos  | *please add email* |
+| @lucaborella89 | Luca Borella | *please add organization* | *please add email* |
+| @niamhoparker | Niamh Parker | *please add organization* | *please add email* |
+| @smtebbe | *please add name* | *please add organization* | *please add email* |
+| @toshaellison | Tosha Ellison | FINOS | *please add email* |
+| @wendallkaters | Kendall Waters Perez | Linux Foundation | *please add email* |
+| @winmorgan | Win Morgan | *please add organization* | *please add email* |
+
+For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
+
+## Updating this file
+
+All changes to the maintainer list are managed openly:
+
+- **Submit a Pull Request** to this file for any addition, removal, or update.
+- **If your project's governance requires a vote**, document or link to the vote outcome in the PR description or comments.
+- This process creates a public audit trail of project leadership over time.
+
+Please email **help@finos.org** whenever this file is updated with a change to maintainership.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,18 +6,18 @@ This file lists the maintainers of this repository.
 
 | GitHub Username | Name | Organization | Email |
 |----------------|------|--------------|-------|
-| @ChrisTyree | *please add name* | *please add organization* | *please add email* |
-| @alstratigos | *please add name* | FINOS | *please add email* |
-| @eteridvalishvili | *please add name* | *please add organization* | *please add email* |
+| @ChrisTyree | *please add name* | *please add organization* |  |
+| @alstratigos | *please add name* | FINOS |  |
+| @eteridvalishvili | *please add name* | *please add organization* |  |
 | @grizzwolf | Aaron Griswold | FINOS & The Linux Foundation | aaron.griswold@finos.org |
-| @jgavronsky | *please add name* | *please add organization* | *please add email* |
-| @karlmoll | *please add name* | @finos  | *please add email* |
-| @lucaborella89 | Luca Borella | *please add organization* | *please add email* |
-| @niamhoparker | Niamh Parker | *please add organization* | *please add email* |
-| @smtebbe | *please add name* | *please add organization* | *please add email* |
-| @toshaellison | Tosha Ellison | FINOS | *please add email* |
-| @wendallkaters | Kendall Waters Perez | Linux Foundation | *please add email* |
-| @winmorgan | Win Morgan | *please add organization* | *please add email* |
+| @jgavronsky | *please add name* | *please add organization* |  |
+| @karlmoll | *please add name* | @finos  |  |
+| @lucaborella89 | Luca Borella | *please add organization* |  |
+| @niamhoparker | Niamh Parker | *please add organization* |  |
+| @smtebbe | *please add name* | *please add organization* |  |
+| @toshaellison | Tosha Ellison | FINOS |  |
+| @wendallkaters | Kendall Waters Perez | Linux Foundation |  |
+| @winmorgan | Win Morgan | *please add organization* |  |
 
 For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,8 @@ This file lists the maintainers of this repository.
 
 ## Current maintainers
 
-| GitHub Username | Name | Organization | Email |
-|----------------|------|--------------|-------|
+| GitHub Username | Name | Organization | Email (optional) |
+|----------------|------|--------------|------------------|
 | @ChrisTyree | *please add name* | *please add organization* |  |
 | @alstratigos | *please add name* | FINOS |  |
 | @eteridvalishvili | *please add name* | *please add organization* |  |


### PR DESCRIPTION
This PR adds a `MAINTAINERS.md` file to the root of this repository as part of a FINOS-wide effort to standardize maintainer signaling across all FINOS projects. An announcement was sent to **community@finos.org** with the full context, see [announcement email here](https://groups.google.com/u/1/a/finos.org/g/community/c/QkcKUec9O4w).

## How this list was generated

The maintainers were determined from this repository's GitHub settings:
- Users with `maintain` or `admin` role on the repository
- Members of teams with `maintain` or `admin` permission


Each entry includes the GitHub username, name, and organization pulled from the user's public GitHub profile. Where name or organization is missing, a `*please add ...*` placeholder marks where to fill in the value. Email is optional: it is included when the user has a public GitHub email, otherwise the cell is left blank.

**If no maintainers were detected automatically** (e.g. your repo has no users or teams with `maintain`/`admin` role), the table is intentionally empty. Please populate it manually on this branch before merging and email help@finos.org.

## What we need from this project's maintainers

1. **Review** the list for completeness and accuracy.
2. **Update** any incorrect or placeholder values (names, organization) directly on this branch. Email is optional.
3. **Add** anyone missing, edit the file in this PR if a maintainer was not automatically detected.
4. **Merge** when the list is accurate.

If your project does not need a `MAINTAINERS.md` for any reason, just close this PR and let us know at help@finos.org.

If this repository should instead be archived (e.g. it is no longer actively maintained or has been superseded), please email help@finos.org instead so we can coordinate the archival with you.

If you already have a MAINTAINERS.md file, you can close this PR. Please update your existing file if needed and place it in the root of the repository.

## Multi-repo projects: share one MAINTAINERS.md

If this repository is part of a project with multiple repositories that share (and will continue to share) the same maintainers, you don't need a separate list per repo. Pick one repository (typically the project's main/umbrella repo) to host the canonical `MAINTAINERS.md`, and on every other repo replace the table in this PR with a short note pointing readers there, for example:

> The maintainers of this repository are listed in the main project repository. See list [here](https://github.com/finos/PROJECT-MAIN-REPO/blob/main/MAINTAINERS.md).

That way maintainer changes only need to be made in one place going forward.

## Going forward: keeping the list current

To keep maintainer changes transparent and aligned with open governance:
- **Any change to the maintainer list must be made via a PR to this file.**
- If your project's governance requires a vote, **document or link to the vote outcome in the PR description or comments.**
- This gives the community a public audit trail of project leadership over time.

If you have any questions about the format or process, please email **help@finos.org**.

Thank you for your review!